### PR TITLE
Add namespace to PSR-4 autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,18 @@
   ],
   "autoload": {
     "psr-4": {
-      "Neoflow\\Session\\": "src/"
+      "Neoflow\\Session\\": "src/Neoflow/Session/"
+    },
+    "autoload-dev": {
+      "psr-4": {
+        "Neoflow\\Session\\Test\\": "tests/"
+      }
     }
   },
   "scripts": {
     "run php-cs-fixer": "php-cs-fixer fix",
     "run php-cs-fixer dry": "php-cs-fixer fix --dry-run",
-    "run phpunit": "phpunit --configuration phpunit.xml.dist"
+    "run phpunit": "phpunit --configuration phpunit.xml.dist",
   },
   "require": {
     "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "scripts": {
     "run php-cs-fixer": "php-cs-fixer fix",
     "run php-cs-fixer dry": "php-cs-fixer fix --dry-run",
-    "run phpunit": "phpunit --configuration phpunit.xml.dist",
+    "run phpunit": "phpunit --configuration phpunit.xml.dist"
   },
   "require": {
     "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "autoload": {
     "psr-4": {
-      "": "src/"
+      "Neoflow\\Session\\": "src/"
     }
   },
   "scripts": {

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Neoflow\Session\Test;
+
 use Middlewares\Utils\Dispatcher;
 use Neoflow\Session\Flash;
 use Neoflow\Session\FlashInterface;

--- a/tests/SessionExceptionTest.php
+++ b/tests/SessionExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Neoflow\Session\Test;
+
 use Middlewares\Utils\Dispatcher;
 use Neoflow\Session\Exception\SessionException;
 use Neoflow\Session\Flash;

--- a/tests/SessionMiddlewareTest.php
+++ b/tests/SessionMiddlewareTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Neoflow\Session\Test;
+
 use Middlewares\Utils\Dispatcher;
 use Neoflow\Session\Middleware\SessionMiddleware;
 use Neoflow\Session\Session;

--- a/tests/SessionNotStartedTest.php
+++ b/tests/SessionNotStartedTest.php
@@ -1,8 +1,11 @@
 <?php
 
+namespace Neoflow\Session\Test;
+
 use Neoflow\Session\Flash;
 use Neoflow\Session\Session;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class SessionNotStartedTest extends TestCase
 {

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -1,11 +1,14 @@
 <?php
 
+namespace Neoflow\Session\Test;
+
 use Middlewares\Utils\Dispatcher;
 use Neoflow\Session\Flash;
 use Neoflow\Session\Middleware\SessionMiddleware;
 use Neoflow\Session\Session;
 use Neoflow\Session\SessionInterface;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class SessionTest extends TestCase
 {


### PR DESCRIPTION
The PR inserts the missing namespace under the psr-4 key.

https://getcomposer.org/doc/04-schema.md#psr-4

I also would recommend moving all files from `src/Neoflow/Session` to `src/`.
